### PR TITLE
updater.bat: replace more with type to be compatible with utf8

### DIFF
--- a/Updater.bat
+++ b/Updater.bat
@@ -64,7 +64,7 @@ wmic datafile where name='%HERE_DS%App\\Obsidian\\Obsidian.exe' get version | %B
  | %BUSYBOX% cut -c 6- ^
  | %BUSYBOX% rev > current.txt
 
-for /f %%V in ('more current.txt') do (set CURRENT=%%V)
+for /f %%V in ('type current.txt') do (set CURRENT=%%V)
 echo Current: %CURRENT%
 
 :LATEST
@@ -73,7 +73,7 @@ set LATEST_URL="https://github.com/obsidianmd/obsidian-releases/releases/latest"
 
 %CURL% -I -s %CURL_PROXY% %LATEST_URL% | %BUSYBOX% grep -o tag/v[0-9.]\+[0-9] | %BUSYBOX% cut -d "v" -f2 > latest.txt
 
-for /f %%V in ('more latest.txt') do (set LATEST=%%V)
+for /f %%V in ('type latest.txt') do (set LATEST=%%V)
 echo Latest: %LATEST%
 echo:
 


### PR DESCRIPTION
OS Windows 7 x64, Obsidian portable updater https://github.com/Numstr/Obsidian-Portable/commit/13530fa93f935e4342d51942697f6a011631cfb2 (Jan 10, 2025).

When codepage (chcp) is 65001, `more somefile.txt` throws an error.
It says `Not enough memory` because somefile.txt was previously created in UTF8.
As a result, it becomes impossible to continue updating.
There is no such issue with `type somefile.txt`.